### PR TITLE
Add CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: $HOME/.cargo
+          key: cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,24 @@
-use clap::{Arg, App};
+use clap::{App, Arg};
 
 fn main() {
     let args = App::new("")
         .version("1.0")
         .author("Bradley Nelson <bradleynelson102@gmail.com>")
         .about("Home Assistant Linux Companion App")
-        .arg(Arg::with_name("config")
-            .short("c")
-            .long("config")
-            )
-        .arg(Arg::with_name("v")
-            .short("v")
-            .multiple(true)
-            .help("Sets the level of verbosity"))
-        .subcommand(App::new("setup")
-            .about("Setup Application"))  
+        .arg(Arg::with_name("config").short("c").long("config"))
+        .arg(
+            Arg::with_name("v")
+                .short("v")
+                .multiple(true)
+                .help("Sets the level of verbosity"),
+        )
+        .subcommand(App::new("setup").about("Setup Application"))
         .get_matches();
 
     match args.subcommand() {
         ("setup", Some(sub_m)) => command_setup(sub_m),
-        _ =>{}
+        _ => {}
     }
 }
 
-fn command_setup(args: &clap::ArgMatches) {
-    
-}
+fn command_setup(args: &clap::ArgMatches) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 
     match args.subcommand() {
         ("setup", Some(sub_m)) => command_setup(sub_m),
-       _ =>{
+        _ => {
             println!("Nothing to do, Goodbye");
         }
     }


### PR DESCRIPTION
Add a CI config, similar to the one I used on https://github.com/RealOrangeOne/date-group.

- Win / mac / Linux builds
- Check linting with `cargo fmt`
- Check patterns with `cargo clippy`
- Run tests with `cargo test` (when they exist)

Ran `cargo fmt` for the first time here, so tests should pass immediately.